### PR TITLE
Pass unparsed arguments to start

### DIFF
--- a/bin/yackage.js
+++ b/bin/yackage.js
@@ -63,7 +63,8 @@ async function start() {
     opts.cacheDir,
     `yode-${opts.yodeVersion}-${opts.platform}-${opts.arch}`,
     process.platform == 'win32' ? 'yode.exe' : 'yode')
-  const child = spawn(yode, [opts.appDir])
+  const args = [opts.appDir].concat(program.args.slice(0, program.args.length - 1));
+  const child = spawn(yode, args);
   child.stdout.pipe(process.stdout)
   child.stderr.pipe(process.stderr)
 }


### PR DESCRIPTION
A basic PR to pass unparsed arguments to the start command. This could be a little bit more featured such as using a `--` argument though I think yode already does some weird stuff with that. I found this to be the easiest way to go about it.