### PR TITLE
Fix executable name in mac bundle

### DIFF
--- a/lib/mac.js
+++ b/lib/mac.js
@@ -40,7 +40,7 @@ async function createBundle(appInfo, appDir, outputDir, target) {
   await fs.ensureDir(`${bundleDir}/Contents/Resources`)
   const exeDir = `${bundleDir}/Contents/MacOS`
   await fs.ensureDir(exeDir)
-  await fs.rename(target, `${exeDir}/${appInfo.productName}`)
+  await fs.rename(target, `${exeDir}/${appInfo.name}`)
   await ignoreError(fs.rename(`${outputDir}/res`, `${exeDir}/res`))
   const infoPlist = infoPlistTemplate.replace(/{{NAME}}/g, appInfo.name)
                                      .replace(/{{PRODUCT_NAME}}/g, appInfo.productName)


### PR DESCRIPTION
The executable is declared as `appInfo.name`, but its actual file name was `appInfo.productName`.
Change the file name to `appInfo.name`.

This should fix yue/wey#44.